### PR TITLE
Lowercase block editor and classic editor to follow core spelling convention

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,7 +28,7 @@ Fixed bug: new palette color are not save due to logic error
 - Fixed JavaScript bug
 
 = 1.13 =
-- Added Gutenberg/Block Editor support
+- Added Gutenberg/block editor support
 - Transparency channel is now always visible inside the palette editor
 - Transparency can now be toggled individually for those integrations that use it
 - Colors can be deactivated to hide them inside the block editor but retain their assignment on a block level

--- a/index.php
+++ b/index.php
@@ -1666,8 +1666,8 @@ jQuery.wp.wpColorPicker.prototype.options.palettes = ["' . $colors . '"];
                 'content' => '
 <p>' . __('You can create a color palette and include it to the Visual Editor and/or the Theme Customizer.', 'kt-tinymce-color-grid') . '</p>
 <p>' . __("<strong>Add to Theme Customizer</strong> makes the palette available to the color picker of the Theme Customizer. This works by altering WordPress' color picker so every plugin using it receives the palette as well.", 'kt-tinymce-color-grid') . '</p>
-<p>' . __('<strong>Add to Block Editor</strong> adds the palette to the color picker of the new Block Editor.', 'kt-tinymce-color-grid') . '</p>
-<p>' . __('<strong>Add to Classic Editor</strong> adds the palette to the color picker of the Classic Editor. This only works if you choose a color grid other than <strong>Default</strong>.', 'kt-tinymce-color-grid') . '</p>'
+<p>' . __('<strong>Add to block editor</strong> adds the palette to the color picker of the new block editor.', 'kt-tinymce-color-grid') . '</p>
+<p>' . __('<strong>Add to classic editor</strong> adds the palette to the color picker of the classic editor. This only works if you choose a color grid other than <strong>Default</strong>.', 'kt-tinymce-color-grid') . '</p>'
             ));
             $screen->add_help_tab(array(
                 'id' => 'grid',
@@ -1949,7 +1949,7 @@ jQuery.wp.wpColorPicker.prototype.options.palettes = ["' . $colors . '"];
                 print "
     <p class='integrate-toggle'>
       <input type='checkbox' id='kt_gutenberg' name='kt_gutenberg' tabindex='9' value='1'$gutenberg_checked data-form='1' />
-      <label for='kt_gutenberg'>" . esc_html__('Add to Block Editor', 'kt-tinymce-color-grid') . "</label>
+      <label for='kt_gutenberg'>" . esc_html__('Add to block editor', 'kt-tinymce-color-grid') . "</label>
     </p>
     <p class='integrate-form$merge_hidden' id='kt_gutenberg_form'>
       <input type='checkbox' id='kt_gutenberg_merge' name='kt_gutenberg_merge' tabindex='9' value='1'$gutenberg_merge_checked />
@@ -1961,7 +1961,7 @@ jQuery.wp.wpColorPicker.prototype.options.palettes = ["' . $colors . '"];
             print "
     <p class='integrate-toggle' id='kt_visual_option'>
       <input type='checkbox' id='kt_visual' name='kt_visual' tabindex='9' value='1'$visual_checked />
-      <label for='kt_visual'>" . esc_html__('Add to Classic Editor', 'kt-tinymce-color-grid') . "</label>
+      <label for='kt_visual'>" . esc_html__('Add to classic editor', 'kt-tinymce-color-grid') . "</label>
     </p>
   </div>";
 

--- a/readme.md
+++ b/readme.md
@@ -12,13 +12,13 @@ Tags: color, customizer, editor, gutenberg, palette, picker, tinymce
 License: GPLv2 or later  
 License URI: http://www.gnu.org/licenses/gpl-2.0.html  
 
-Manage a site-wide central color palette for an uniform look'n'feel! Supports the new Block Editor, Theme Customizer and many themes and plugins.
+Manage a site-wide central color palette for an uniform look'n'feel! Supports the new block editor, Theme Customizer and many themes and plugins.
 
 ## Description
 
-This plugin allows you to manage a site-wide central color palette for an uniform look'n'feel. The palette of the new Block Editor and the Theme Customizer are supported, as well as the Classic Editor. You can define this central color palette through the settings menu. All plugins that make use of WordPress' color picker can benefit from this plugin as well.
+This plugin allows you to manage a site-wide central color palette for an uniform look'n'feel. The palette of the new block editor and the Theme Customizer are supported, as well as the classic editor. You can define this central color palette through the settings menu. All plugins that make use of WordPress' color picker can benefit from this plugin as well.
 
-Also this plugin replaces the color picker for choosing a text or background color found inside the Classic Editor with a bigger and customizable color grid.
+Also this plugin replaces the color picker for choosing a text or background color found inside the classic editor with a bigger and customizable color grid.
 
 For an easy migration between WordPress installations you can export and import your palette settings and colors.
 

--- a/readme.txt
+++ b/readme.txt
@@ -8,13 +8,13 @@ Tags: color, customizer, editor, gutenberg, palette, picker, tinymce
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Manage a site-wide central color palette for an uniform look'n'feel! Supports the new Block Editor, Theme Customizer and many themes and plugins.
+Manage a site-wide central color palette for an uniform look'n'feel! Supports the new block editor, Theme Customizer and many themes and plugins.
 
 == Description ==
 
-This plugin allows you to manage a site-wide central color palette for an uniform look'n'feel. The palette of the new Block Editor and the Theme Customizer are supported, as well as the Classic Editor. You can define this central color palette through the settings menu. All plugins that make use of WordPress' color picker can benefit from this plugin as well.
+This plugin allows you to manage a site-wide central color palette for an uniform look'n'feel. The palette of the new block editor and the Theme Customizer are supported, as well as the classic editor. You can define this central color palette through the settings menu. All plugins that make use of WordPress' color picker can benefit from this plugin as well.
 
-Also this plugin replaces the color picker for choosing a text or background color found inside the Classic Editor with a bigger and customizable color grid.
+Also this plugin replaces the color picker for choosing a text or background color found inside the classic editor with a bigger and customizable color grid.
 
 For an easy migration between WordPress installations you can export and import your palette settings and colors.
 
@@ -68,9 +68,9 @@ Please [contact me](http://wordpress.org/support/plugin/kt-tinymce-color-grid) a
 == Screenshots ==
 
 1. The Color Palette Editor
-2. The new Block Editor is supported
+2. The new block editor is supported
 3. Custom palette for the Theme Customizer
-4. Legacy support for the Classic Editor
+4. Legacy support for the classic editor
 
 == Changelog ==
 
@@ -104,7 +104,7 @@ Fixed bug: new palette color are not save due to logic error
 - Fixed JavaScript bug
 
 = 1.13 =
-- Added Gutenberg/Block Editor support
+- Added Gutenberg/block editor support
 - Transparency channel is now always visible inside the palette editor
 - Transparency can now be toggled individually for those integrations that use it
 - Colors can be deactivated to hide them inside the block editor but retain their assignment on a block level
@@ -254,7 +254,7 @@ Fixes incompatibility with Elementor Pro and added support for Neve Theme
 Fixes broken import
 
 = 1.13 =
-Adds Gutenberg/Block Editor support and more export formats
+Adds Gutenberg/block editor support and more export formats
 
 = 1.12.6 =
 Customizer palette breaks into rows of 8 rows


### PR DESCRIPTION
Reference: https://make.wordpress.org/core/handbook/best-practices/spelling/


“block editor” or “block-based editor” | “Block Editor” or “Gutenberg” | When referring to the new editor.
“Classic Editor” | “classic editor” | When referring to the Classic Editor plugin.
“classic editor” | “Classic Editor” | When referring to the classic editor interface and not the plugin.

